### PR TITLE
Series monitoring

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -35,7 +35,7 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(me
 logger = logging.getLogger(__name__)
 
 # Application version
-APP_VERSION = "0.3.0"
+APP_VERSION = "0.3.1"
 GITHUB_REPO = "SpanishST/xtreamfilter"
 
 # Data directory - use environment variable or default to /data (Docker) or ./data (local)

--- a/app/templates/browse.html
+++ b/app/templates/browse.html
@@ -161,6 +161,23 @@
         .cart-badge { position: absolute; top: -5px; right: -8px; background: #ff4757; color: #fff; font-size: 0.65em; font-weight: 700; min-width: 18px; height: 18px; border-radius: 9px; display: flex; align-items: center; justify-content: center; padding: 0 4px; }
         .source-row .source-row-cart-btn { width: 24px; height: 24px; border-radius: 50%; background: rgba(0, 0, 0, 0.4); border: none; cursor: pointer; display: flex; align-items: center; justify-content: center; font-size: 0.85em; color: rgba(255, 255, 255, 0.5); transition: all 0.2s; }
         .source-row .source-row-cart-btn:hover { color: #2ed573; background: rgba(0, 0, 0, 0.6); }
+        /* Monitor button */
+        .add-monitor-btn { position: absolute; top: 10px; right: 94px; width: 36px; height: 36px; border-radius: 50%; background: rgba(0, 0, 0, 0.6); border: none; cursor: pointer; display: flex; align-items: center; justify-content: center; font-size: 1.1em; transition: all 0.2s; color: rgba(255, 255, 255, 0.7); }
+        .add-monitor-btn:hover { transform: scale(1.1); background: rgba(0, 0, 0, 0.8); color: #a29bfe; }
+        /* Monitor modal form */
+        .monitor-form .form-group { margin-bottom: 15px; }
+        .monitor-form .form-group label { display: block; margin-bottom: 6px; color: #888; font-size: 0.9em; }
+        .monitor-form .scope-options { display: flex; gap: 8px; flex-wrap: wrap; }
+        .monitor-form .scope-option { padding: 10px 16px; border: 1px solid rgba(255, 255, 255, 0.1); border-radius: 8px; cursor: pointer; text-align: center; transition: all 0.2s; flex: 1; min-width: 90px; }
+        .monitor-form .scope-option:hover { background: rgba(255, 255, 255, 0.05); }
+        .monitor-form .scope-option.selected { background: rgba(0, 212, 255, 0.15); border-color: #00d4ff; color: #00d4ff; }
+        .monitor-form .scope-option .scope-title { font-weight: 600; font-size: 0.95em; margin-bottom: 3px; }
+        .monitor-form .scope-option .scope-desc { font-size: 0.75em; color: #888; }
+        .monitor-form select { width: 100%; padding: 10px; border: 1px solid rgba(255, 255, 255, 0.1); border-radius: 6px; background: rgba(0, 0, 0, 0.3); color: #fff; font-size: 0.95em; }
+        .monitor-form .source-options { display: flex; gap: 8px; flex-wrap: wrap; }
+        .monitor-form .source-option { padding: 10px 16px; border: 1px solid rgba(255, 255, 255, 0.1); border-radius: 8px; cursor: pointer; transition: all 0.2s; flex: 1; min-width: 120px; text-align: center; }
+        .monitor-form .source-option:hover { background: rgba(255, 255, 255, 0.05); }
+        .monitor-form .source-option.selected { background: rgba(162, 155, 254, 0.15); border-color: #a29bfe; color: #a29bfe; }
         /* Episode selector modal */
         .episode-list { max-height: 400px; overflow-y: auto; }
         .season-group { margin-bottom: 15px; }
@@ -190,6 +207,7 @@
                 <span id="version-badge" style="display: none; font-size: 0.65em; padding: 3px 10px; border-radius: 12px; background: rgba(255,255,255,0.08); color: #888; cursor: default;"></span>
             </div>
             <div class="header-nav">
+                <a href="/monitor" class="btn btn-secondary">📡 Monitor</a>
                 <a href="/cart" class="btn btn-secondary cart-link">🛒 Cart<span class="cart-badge" id="cart-badge" style="display:none">0</span></a>
                 <a href="/" class="btn btn-secondary">Settings</a>
             </div>
@@ -407,6 +425,68 @@
             </div>
             <div class="modal-footer">
                 <button class="btn btn-secondary" onclick="closeEpisodeModal()">Close</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Series Monitor Modal -->
+    <div class="modal-overlay" id="monitor-modal">
+        <div class="modal" style="max-width: 500px;">
+            <div class="modal-header">
+                <h2 id="monitor-modal-title">📡 Monitor Series</h2>
+                <button class="modal-close" onclick="closeMonitorModal()">&times;</button>
+            </div>
+            <div class="modal-body monitor-form">
+                <div class="form-group">
+                    <label>What to monitor</label>
+                    <div class="scope-options">
+                        <div class="scope-option selected" data-scope="new_only" onclick="selectMonitorScope('new_only')">
+                            <div class="scope-title">New Only</div>
+                            <div class="scope-desc">Future episodes</div>
+                        </div>
+                        <div class="scope-option" data-scope="all" onclick="selectMonitorScope('all')">
+                            <div class="scope-title">All</div>
+                            <div class="scope-desc">Every episode</div>
+                        </div>
+                        <div class="scope-option" data-scope="season" onclick="selectMonitorScope('season')">
+                            <div class="scope-title">Season</div>
+                            <div class="scope-desc">One season</div>
+                        </div>
+                    </div>
+                </div>
+                <div class="form-group" id="monitor-season-group" style="display:none;">
+                    <label>Season</label>
+                    <select id="monitor-season-select"><option value="">Loading...</option></select>
+                </div>
+                <div class="form-group">
+                    <label>Source</label>
+                    <div class="source-options" id="monitor-source-options">
+                        <div class="source-option selected" data-source="any" onclick="selectMonitorSource('any')">
+                            Any source (first found)
+                        </div>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label>Action</label>
+                    <div class="scope-options">
+                        <div class="scope-option action-option selected" data-action="both" onclick="selectMonitorAction('both')">
+                            <div class="scope-title">Both</div>
+                            <div class="scope-desc">Download + Notify</div>
+                        </div>
+                        <div class="scope-option action-option" data-action="download" onclick="selectMonitorAction('download')">
+                            <div class="scope-title">Download</div>
+                            <div class="scope-desc">Download only</div>
+                        </div>
+                        <div class="scope-option action-option" data-action="notify" onclick="selectMonitorAction('notify')">
+                            <div class="scope-title">Notify</div>
+                            <div class="scope-desc">Telegram only</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-secondary" onclick="closeMonitorModal()">Cancel</button>
+                <button class="btn btn-primary" onclick="confirmMonitor()">📡 Start Monitoring</button>
             </div>
         </div>
     </div>
@@ -678,9 +758,14 @@
                 ? '<button class="add-cart-btn" data-source-id="' + escapeAttr(item.source_id) + '" data-item-id="' + escapeAttr(item.id) + '" data-content-type="' + escapeAttr(contentType) + '" data-name="' + escapeAttr(item.name) + '" data-icon="' + escapeAttr(item.icon || '') + '" data-group="' + escapeAttr(item.group || '') + '" data-ext="' + escapeAttr(item.container_extension || 'mp4') + '" title="Add to download cart">🛒</button>'
                 : '';
 
+            const monitorBtn = (contentType === 'series')
+                ? '<button class="add-monitor-btn" onclick="openMonitorModal(event, \'' + escapeAttr(item.source_id) + '\', \'' + escapeAttr(item.id) + '\', \'' + jsEscape(item.name) + '\', \'' + escapeAttr(item.icon || '') + '\', \'' + escapeAttr(item.source_name || '') + '\')" title="Monitor this series">📡</button>'
+                : '';
+
             return '<div class="content-card">' +
                 (isNew ? '<div class="new-badge">NEW</div>' : '') +
                 cartBtn +
+                monitorBtn +
                 '<button class="add-category-btn' + (hasCats ? ' has-categories' : '') + '" onclick="toggleCategoryDropdown(event, \'' + item.source_id + '\', \'' + item.id + '\', \'' + contentType + '\')">+</button>' +
                 '<div class="category-dropdown" id="cat-dropdown-' + item.source_id + '-' + item.id + '"></div>' +
                 posterHtml +
@@ -735,6 +820,27 @@
                 groupCartBtn = '<button class="add-cart-btn" data-source-id="' + escapeAttr(group.items[0].source_id) + '" data-item-id="' + escapeAttr(group.items[0].id) + '" data-content-type="' + escapeAttr(contentType) + '" data-name="' + escapeAttr(group.name) + '" data-icon="' + escapeAttr(group.icon || '') + '" data-group="' + escapeAttr(group.items[0].group || '') + '" data-ext="' + escapeAttr(group.items[0].container_extension || 'mp4') + '" data-all-sources="' + escapeAttr(JSON.stringify(allSourcesData)) + '" title="Add to download cart">🛒</button>';
             }
 
+            // Monitor button for grouped series cards
+            let groupMonitorBtn = '';
+            if (contentType === 'series') {
+                // Build all-sources data for monitor modal (deduplicated by source_id+series_id)
+                const seenSourceSeries = new Set();
+                const monitorSourcesData = [];
+                for (const sub of group.items) {
+                    const key = sub.source_id + '|' + sub.id;
+                    if (!seenSourceSeries.has(key)) {
+                        seenSourceSeries.add(key);
+                        monitorSourcesData.push({
+                            source_id: sub.source_id,
+                            source_name: sub.source_name || 'Unknown',
+                            series_id: sub.id,
+                            category: sub.group || '',
+                        });
+                    }
+                }
+                groupMonitorBtn = '<button class="add-monitor-btn" onclick="openMonitorModal(event, null, \'' + escapeAttr(group.items[0].id) + '\', \'' + jsEscape(group.name) + '\', \'' + escapeAttr(group.icon || '') + '\', null, ' + escapeAttr(JSON.stringify(monitorSourcesData)) + ')" title="Monitor this series">📡</button>';
+            }
+
             // Build source rows for expand area
             const sourceRows = group.items.map(sub => {
                 const si = sources.findIndex(s => s.id === sub.source_id) + 1;
@@ -759,6 +865,7 @@
             return '<div class="content-card">' +
                 (isNew ? '<div class="new-badge">NEW</div>' : '') +
                 groupCartBtn +
+                groupMonitorBtn +
                 posterHtml +
                 '<div class="card-info">' +
                 '<div class="card-title">' + escapeHtml(group.name) +
@@ -1375,6 +1482,157 @@
             }).catch(() => {});
         }
         checkVersion();
+
+        // ============================================
+        // SERIES MONITOR FUNCTIONS
+        // ============================================
+        let _monitorModalData = {};
+
+        function openMonitorModal(event, sourceId, seriesId, seriesName, icon, sourceName, allSources) {
+            event.stopPropagation();
+            event.preventDefault();
+
+            _monitorModalData = {
+                sourceId: sourceId,
+                seriesId: seriesId,
+                seriesName: seriesName,
+                icon: icon || '',
+                sourceName: sourceName || '',
+                allSources: allSources || null,
+            };
+
+            const modal = document.getElementById('monitor-modal');
+            document.getElementById('monitor-modal-title').textContent = '📡 Monitor: ' + seriesName;
+
+            // Reset scope
+            selectMonitorScope('new_only');
+            document.getElementById('monitor-season-group').style.display = 'none';
+
+            // Reset action
+            selectMonitorAction('both');
+
+            // Build source options
+            const sourceContainer = document.getElementById('monitor-source-options');
+            let sourceHtml = '<div class="source-option selected" data-source="any" onclick="selectMonitorSource(\'any\')">Any source (first found)</div>';
+
+            if (allSources && allSources.length > 0) {
+                for (const s of allSources) {
+                    const sourceKey = s.source_id + '|' + s.series_id;
+                    const catLabel = s.category ? ' <span style="opacity:0.5;font-size:0.85em">(' + escapeHtml(s.category) + ')</span>' : '';
+                    sourceHtml += '<div class="source-option" data-source-key="' + escapeAttr(sourceKey) + '" data-source="' + escapeAttr(s.source_id) + '" data-series-id="' + escapeAttr(s.series_id) + '" data-source-name="' + escapeAttr(s.source_name) + '" data-category="' + escapeAttr(s.category || '') + '" onclick="selectMonitorSource(\'' + escapeAttr(sourceKey) + '\')">' + escapeHtml(s.source_name) + catLabel + '</div>';
+                }
+            } else if (sourceId) {
+                const sourceKey = sourceId + '|' + seriesId;
+                sourceHtml += '<div class="source-option" data-source-key="' + escapeAttr(sourceKey) + '" data-source="' + escapeAttr(sourceId) + '" data-series-id="' + escapeAttr(seriesId) + '" data-source-name="' + escapeAttr(sourceName || '') + '" data-category="" onclick="selectMonitorSource(\'' + escapeAttr(sourceKey) + '\')">' + escapeHtml(sourceName || sourceId) + '</div>';
+            }
+            sourceContainer.innerHTML = sourceHtml;
+
+            // Load season list for season scope
+            _loadSeasonsList(sourceId || (allSources && allSources.length > 0 ? allSources[0].source_id : null),
+                             seriesId || (allSources && allSources.length > 0 ? allSources[0].series_id : null));
+
+            modal.classList.add('show');
+        }
+
+        async function _loadSeasonsList(sourceId, seriesId) {
+            const seasonSelect = document.getElementById('monitor-season-select');
+            seasonSelect.innerHTML = '<option value="">Loading...</option>';
+            if (!sourceId || !seriesId) return;
+
+            try {
+                const resp = await fetch('/api/cart/series-episodes/' + sourceId + '/' + seriesId);
+                const data = await resp.json();
+                if (data.seasons) {
+                    const seasonNums = Object.keys(data.seasons).sort((a, b) => parseInt(a) - parseInt(b));
+                    seasonSelect.innerHTML = seasonNums.map(s => '<option value="' + s + '">Season ' + s + ' (' + data.seasons[s].length + ' episodes)</option>').join('');
+                }
+            } catch (e) {
+                seasonSelect.innerHTML = '<option value="">Error loading seasons</option>';
+            }
+        }
+
+        function selectMonitorScope(scope) {
+            document.querySelectorAll('#monitor-modal .scope-option').forEach(o => {
+                o.classList.toggle('selected', o.dataset.scope === scope);
+            });
+            document.getElementById('monitor-season-group').style.display = scope === 'season' ? 'block' : 'none';
+            _monitorModalData.scope = scope;
+        }
+
+        function selectMonitorSource(sourceKey) {
+            document.querySelectorAll('#monitor-modal .source-option').forEach(o => {
+                const key = o.dataset.sourceKey || o.dataset.source;
+                o.classList.toggle('selected', key === sourceKey);
+            });
+            _monitorModalData.selectedSource = sourceKey;
+        }
+
+        function selectMonitorAction(action) {
+            document.querySelectorAll('#monitor-modal .action-option').forEach(o => {
+                o.classList.toggle('selected', o.dataset.action === action);
+            });
+            _monitorModalData.action = action;
+        }
+
+        function closeMonitorModal() {
+            document.getElementById('monitor-modal').classList.remove('show');
+            _monitorModalData = {};
+        }
+
+        async function confirmMonitor() {
+            const d = _monitorModalData;
+            const scope = d.scope || 'new_only';
+            const selectedSource = d.selectedSource || 'any';
+            const seasonFilter = scope === 'season' ? document.getElementById('monitor-season-select').value : null;
+
+            if (scope === 'season' && !seasonFilter) {
+                showToast('Please select a season', 'error');
+                return;
+            }
+
+            let sourceId = null;
+            let sourceName = null;
+            let sourceCategory = null;
+            let seriesId = d.seriesId;
+
+            if (selectedSource !== 'any') {
+                // selectedSource is a composite key "source_id|series_id" or just a source_id
+                const sourceOption = document.querySelector('#monitor-modal .source-option.selected');
+                if (sourceOption) {
+                    sourceId = sourceOption.dataset.source;
+                    sourceName = sourceOption.dataset.sourceName || sourceOption.textContent.trim();
+                    sourceCategory = sourceOption.dataset.category || null;
+                    if (sourceOption.dataset.seriesId) seriesId = sourceOption.dataset.seriesId;
+                }
+            }
+
+            try {
+                const resp = await fetch('/api/monitor', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        series_name: d.seriesName,
+                        series_id: seriesId,
+                        source_id: sourceId,
+                        source_name: sourceName,
+                        source_category: sourceCategory,
+                        cover: d.icon,
+                        scope: scope,
+                        season_filter: seasonFilter,
+                        action: d.action || 'both',
+                    })
+                });
+                const data = await resp.json();
+                if (resp.ok) {
+                    showToast('Monitoring started: ' + d.seriesName, 'success');
+                    closeMonitorModal();
+                } else {
+                    showToast(data.error || 'Failed to add monitoring', 'error');
+                }
+            } catch (e) {
+                showToast('Error adding monitoring', 'error');
+            }
+        }
     </script>
 </body>
 </html>

--- a/app/templates/cart.html
+++ b/app/templates/cart.html
@@ -79,6 +79,7 @@
         .status-badge.downloading { background: rgba(255, 165, 2, 0.2); color: #ffa502; }
         .status-badge.completed { background: rgba(46, 213, 115, 0.2); color: #2ed573; }
         .status-badge.failed, .status-badge.cancelled { background: rgba(255, 71, 87, 0.2); color: #ff4757; }
+        .status-badge.move_failed { background: rgba(255, 165, 2, 0.2); color: #ffa502; }
         .item-progress { width: 80px; }
         .item-progress-bar { width: 100%; height: 4px; background: rgba(255, 255, 255, 0.1); border-radius: 2px; overflow: hidden; }
         .item-progress-fill { height: 100%; background: #00d4ff; border-radius: 2px; transition: width 0.5s ease; }
@@ -118,6 +119,7 @@
             </div>
             <div class="header-nav">
                 <a href="/browse" class="btn btn-secondary">Custom categories & Downloads</a>
+                <a href="/monitor" class="btn btn-secondary">📡 Monitor</a>
                 <a href="/" class="btn btn-secondary">Settings</a>
             </div>
         </div>
@@ -131,6 +133,7 @@
                     <div style="display: flex; gap: 8px;">
                         <input type="text" id="download-path" placeholder="/data/downloads">
                         <button class="btn btn-primary btn-small" onclick="saveDownloadPath()" style="white-space:nowrap;">Save</button>
+                        <button class="btn btn-secondary btn-small" onclick="testPath('download-path')" style="white-space:nowrap;">🧪 Test</button>
                     </div>
                 </div>
                 <div class="setting-group" style="flex:1;">
@@ -138,6 +141,7 @@
                     <div style="display: flex; gap: 8px;">
                         <input type="text" id="download-temp-path" placeholder="/data/downloads/.tmp">
                         <button class="btn btn-primary btn-small" onclick="saveTempPath()" style="white-space:nowrap;">Save</button>
+                        <button class="btn btn-secondary btn-small" onclick="testPath('download-temp-path')" style="white-space:nowrap;">🧪 Test</button>
                     </div>
                 </div>
             </div>
@@ -328,6 +332,24 @@
             } catch (e) { showToast('Error saving temp path', 'error'); }
         }
 
+        async function testPath(inputId) {
+            const path = document.getElementById(inputId).value.trim();
+            if (!path) return showToast('Path cannot be empty', 'error');
+            try {
+                const resp = await fetch('/api/options/test_path', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ path: path })
+                });
+                const data = await resp.json();
+                if (resp.ok && data.writable) {
+                    showToast('✅ ' + path + ' — ' + data.message, 'success');
+                } else {
+                    showToast('❌ ' + path + ' — ' + (data.error || data.message || 'Not writable'), 'error');
+                }
+            } catch (e) { showToast('Error testing path', 'error'); }
+        }
+
         let playerProfiles = {};
 
         async function loadThrottleSettings() {
@@ -471,7 +493,10 @@
                 }
 
                 const canRemove = item.status !== 'downloading';
-                const retryBtn = (item.status === 'failed' || item.status === 'cancelled')
+                const moveBtn = (item.status === 'move_failed' && item.temp_path)
+                    ? '<button class="remove-btn" onclick="moveItem(\'' + item.id + '\')" title="Move to destination" style="color:#00d4ff;">📂</button>'
+                    : '';
+                const retryBtn = (item.status === 'failed' || item.status === 'cancelled' || item.status === 'move_failed')
                     ? '<button class="remove-btn" onclick="retryItem(\'' + item.id + '\')" title="Retry" style="color:#ffa502;">🔄</button>'
                     : '';
                 const removeBtn = canRemove
@@ -484,7 +509,7 @@
                     '<td>' + typeBadge + '</td>' +
                     '<td>' + statusBadge + '</td>' +
                     '<td>' + progressHtml + '</td>' +
-                    '<td>' + retryBtn + removeBtn + '</td>' +
+                    '<td>' + moveBtn + retryBtn + removeBtn + '</td>' +
                     '</tr>';
             }).join('');
         }
@@ -598,6 +623,19 @@
                 }
                 await loadCart();
             } catch (e) { showToast('Error retrying item', 'error'); }
+        }
+
+        async function moveItem(itemId) {
+            try {
+                const resp = await fetch('/api/cart/' + itemId + '/move', { method: 'POST' });
+                const data = await resp.json();
+                if (resp.ok) {
+                    showToast(data.message || 'File moved successfully', 'success');
+                } else {
+                    showToast(data.error || 'Move failed', 'error');
+                }
+                await loadCart();
+            } catch (e) { showToast('Error moving file', 'error'); }
         }
 
         async function retryAllFailed() {

--- a/app/templates/cart.html
+++ b/app/templates/cart.html
@@ -174,6 +174,13 @@
                         <span class="input-suffix">seconds</span>
                     </div>
                 </div>
+                <div class="setting-group">
+                    <label>CDN Burst Reconnect</label>
+                    <div style="display: flex; align-items: center; gap: 6px;">
+                        <input type="number" id="throttle-burst-reconnect" min="0" step="5" placeholder="0">
+                        <span class="input-suffix">seconds (0 = off)</span>
+                    </div>
+                </div>
                 <button class="btn btn-primary btn-small" onclick="saveThrottle()" style="align-self:flex-end; white-space:nowrap;">Save Throttle</button>
             </div>
             <div id="player-ua-preview" style="font-size:0.75em; color:#666; margin-top:8px; font-family:monospace;"></div>
@@ -371,6 +378,7 @@
                 document.getElementById('throttle-bandwidth').value = data.bandwidth_limit || 0;
                 document.getElementById('throttle-pause-interval').value = data.pause_interval || 0;
                 document.getElementById('throttle-pause-duration').value = data.pause_duration || 0;
+                document.getElementById('throttle-burst-reconnect').value = data.burst_reconnect || 0;
                 select.value = data.player_profile || 'tivimate';
                 updatePlayerUaPreview();
             } catch (e) { console.error('Error loading throttle settings:', e); }
@@ -391,12 +399,13 @@
             const bw = parseInt(document.getElementById('throttle-bandwidth').value) || 0;
             const interval = parseInt(document.getElementById('throttle-pause-interval').value) || 0;
             const duration = parseInt(document.getElementById('throttle-pause-duration').value) || 0;
+            const burst = parseInt(document.getElementById('throttle-burst-reconnect').value) || 0;
             const profile = document.getElementById('throttle-player-profile').value;
             try {
                 const resp = await fetch('/api/options/download_throttle', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ bandwidth_limit: bw, pause_interval: interval, pause_duration: duration, player_profile: profile })
+                    body: JSON.stringify({ bandwidth_limit: bw, pause_interval: interval, pause_duration: duration, player_profile: profile, burst_reconnect: burst })
                 });
                 const data = await resp.json();
                 if (resp.ok) {

--- a/app/templates/cart.html
+++ b/app/templates/cart.html
@@ -173,6 +173,19 @@
                 <button class="btn btn-primary btn-small" onclick="saveThrottle()" style="align-self:flex-end; white-space:nowrap;">Save Throttle</button>
             </div>
             <div id="player-ua-preview" style="font-size:0.75em; color:#666; margin-top:8px; font-family:monospace;"></div>
+            <div id="telegram-notify-section" style="display:none; margin-top:16px;">
+                <div class="settings-section-title">📨 Telegram Notifications</div>
+                <div class="settings-row" style="gap:20px;">
+                    <label style="display:flex; align-items:center; gap:8px; cursor:pointer; font-size:0.9em;">
+                        <input type="checkbox" id="notify-file" onchange="saveNotifySettings()" style="width:16px; height:16px; accent-color:#00d4ff;">
+                        Notify when each file finishes downloading
+                    </label>
+                    <label style="display:flex; align-items:center; gap:8px; cursor:pointer; font-size:0.9em;">
+                        <input type="checkbox" id="notify-queue" onchange="saveNotifySettings()" style="width:16px; height:16px; accent-color:#00d4ff;">
+                        Notify when the entire queue finishes (with recap)
+                    </label>
+                </div>
+            </div>
         </div>
 
         <!-- Summary -->
@@ -217,6 +230,7 @@
                     <span id="current-speed"></span>
                     <span id="current-size"></span>
                     <span id="current-percent"></span>
+                    <span id="current-eta" style="color:#00d4ff;"></span>
                 </div>
             </div>
             <div class="progress-bar-container">
@@ -260,6 +274,7 @@
         document.addEventListener('DOMContentLoaded', function() {
             loadDownloadPath();
             loadThrottleSettings();
+            loadNotifySettings();
             loadCart();
             startPolling();
         });
@@ -368,6 +383,35 @@
                     showToast(data.error || 'Failed to save', 'error');
                 }
             } catch (e) { showToast('Error saving throttle settings', 'error'); }
+        }
+
+        async function loadNotifySettings() {
+            try {
+                const resp = await fetch('/api/options/download_notifications');
+                const data = await resp.json();
+                if (data.telegram_configured) {
+                    document.getElementById('telegram-notify-section').style.display = '';
+                    document.getElementById('notify-file').checked = !!data.notify_file;
+                    document.getElementById('notify-queue').checked = !!data.notify_queue;
+                }
+            } catch (e) { console.error('Error loading notification settings:', e); }
+        }
+
+        async function saveNotifySettings() {
+            const notifyFile = document.getElementById('notify-file').checked;
+            const notifyQueue = document.getElementById('notify-queue').checked;
+            try {
+                const resp = await fetch('/api/options/download_notifications', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ notify_file: notifyFile, notify_queue: notifyQueue })
+                });
+                if (resp.ok) {
+                    showToast('Notification settings saved', 'success');
+                } else {
+                    showToast('Failed to save notification settings', 'error');
+                }
+            } catch (e) { showToast('Error saving notification settings', 'error'); }
         }
 
         async function loadCart() {
@@ -480,6 +524,18 @@
                     document.getElementById('current-percent').textContent = data.current.progress + '%';
                     document.getElementById('current-progress-bar').style.width = data.current.progress + '%';
 
+                    // Compute ETA
+                    const etaEl = document.getElementById('current-eta');
+                    if (data.current.speed > 0 && data.current.total_bytes > 0) {
+                        const remaining = data.current.total_bytes - data.current.bytes_downloaded;
+                        const etaSec = Math.max(0, Math.round(remaining / data.current.speed));
+                        etaEl.textContent = 'ETA ' + formatDuration(etaSec);
+                    } else if (data.current.total_bytes > 0) {
+                        etaEl.textContent = 'ETA --:--';
+                    } else {
+                        etaEl.textContent = '';
+                    }
+
                     // Show pause indicator
                     const pauseEl = document.getElementById('pause-indicator');
                     if (data.current.paused) {
@@ -577,6 +633,15 @@
             const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
             const i = Math.floor(Math.log(bytes) / Math.log(k));
             return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
+        }
+
+        function formatDuration(totalSeconds) {
+            if (totalSeconds < 60) return totalSeconds + 's';
+            const h = Math.floor(totalSeconds / 3600);
+            const m = Math.floor((totalSeconds % 3600) / 60);
+            const s = totalSeconds % 60;
+            if (h > 0) return h + 'h ' + String(m).padStart(2, '0') + 'm';
+            return m + 'm ' + String(s).padStart(2, '0') + 's';
         }
 
         function escapeHtml(text) {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -681,6 +681,7 @@
                 <span id="version-badge" style="display: none; font-size: 0.7em; padding: 3px 10px; border-radius: 12px; background: rgba(255,255,255,0.08); color: #888; cursor: default;"></span>
             </div>
             <a href="/browse" style="display: inline-block; padding: 12px 25px; background: linear-gradient(135deg, #00d4ff, #0099cc); color: #000; font-weight: 600; border-radius: 8px; text-decoration: none; transition: all 0.3s;" onmouseover="this.style.transform='translateY(-2px)'; this.style.boxShadow='0 5px 20px rgba(0, 212, 255, 0.4)';" onmouseout="this.style.transform='none'; this.style.boxShadow='none';">🔍 Custom categories & Downloads</a>
+            <a href="/monitor" style="display: inline-block; padding: 12px 25px; background: rgba(255, 255, 255, 0.1); color: #fff; border: 1px solid rgba(255, 255, 255, 0.2); border-radius: 8px; text-decoration: none; transition: all 0.3s; margin-left: 10px;" onmouseover="this.style.background='rgba(255,255,255,0.2)';" onmouseout="this.style.background='rgba(255,255,255,0.1)';">📡 Series Monitor</a>
         </div>
         
         <!-- Cache Status Card -->

--- a/app/templates/monitor.html
+++ b/app/templates/monitor.html
@@ -306,6 +306,14 @@
 
             try {
                 const resp = await fetch('/api/monitor/' + id + '/episodes');
+                if (!resp.ok) {
+                    let errMsg = 'Server error (' + resp.status + ')';
+                    try {
+                        const errData = await resp.json();
+                        errMsg = errData.error || errMsg;
+                    } catch (_) {}
+                    throw new Error(errMsg);
+                }
                 const data = await resp.json();
 
                 document.getElementById('preview-summary').innerHTML =
@@ -338,7 +346,8 @@
                 }
                 document.getElementById('preview-list').innerHTML = html;
             } catch (e) {
-                document.getElementById('preview-list').innerHTML = '<p style="color:#ff4757">Error loading preview</p>';
+                document.getElementById('preview-summary').textContent = '';
+                document.getElementById('preview-list').innerHTML = '<p style="color:#ff4757">Error loading preview: ' + escapeHtml(e.message) + '</p>';
             }
         }
 

--- a/app/templates/monitor.html
+++ b/app/templates/monitor.html
@@ -1,0 +1,385 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Series Monitor - XtreamFilter</title>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif; background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); min-height: 100vh; color: #e0e0e0; padding: 20px; }
+        .container { max-width: 1200px; margin: 0 auto; }
+        .header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 30px; flex-wrap: wrap; gap: 15px; }
+        .header h1 { color: #00d4ff; font-size: 2em; text-shadow: 0 0 20px rgba(0, 212, 255, 0.3); }
+        .btn { display: inline-block; padding: 10px 20px; border: none; border-radius: 8px; font-size: 0.95em; cursor: pointer; transition: all 0.3s; text-decoration: none; }
+        .btn-secondary { background: rgba(255, 255, 255, 0.1); color: #fff; border: 1px solid rgba(255, 255, 255, 0.2); }
+        .btn-secondary:hover { background: rgba(255, 255, 255, 0.2); }
+        .btn-primary { background: linear-gradient(135deg, #00d4ff, #0099cc); color: #000; font-weight: 600; }
+        .btn-primary:hover { transform: translateY(-2px); box-shadow: 0 5px 20px rgba(0, 212, 255, 0.4); }
+        .btn-small { padding: 6px 12px; font-size: 0.85em; }
+        .btn-danger { background: rgba(255, 71, 87, 0.2); color: #ff4757; border: 1px solid rgba(255, 71, 87, 0.3); }
+        .btn-danger:hover { background: rgba(255, 71, 87, 0.35); }
+
+        .header-actions { display: flex; gap: 10px; align-items: center; }
+
+        .series-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 20px; margin-top: 20px; }
+
+        .series-card { background: rgba(255, 255, 255, 0.05); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 12px; overflow: hidden; transition: all 0.3s; display: flex; flex-direction: row; }
+        .series-card:hover { border-color: rgba(0, 212, 255, 0.3); box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3); }
+        .series-card.disabled { opacity: 0.5; }
+
+        .series-cover { width: 120px; min-height: 160px; flex-shrink: 0; background: rgba(0, 0, 0, 0.3); display: flex; align-items: center; justify-content: center; }
+        .series-cover img { width: 100%; height: 100%; object-fit: cover; }
+        .series-cover .placeholder { font-size: 3em; opacity: 0.3; }
+
+        .series-details { padding: 15px; flex: 1; display: flex; flex-direction: column; gap: 8px; }
+        .series-name { font-size: 1.1em; font-weight: 600; color: #fff; line-height: 1.3; }
+        .series-meta { display: flex; flex-wrap: wrap; gap: 6px; }
+        .series-badge { font-size: 0.75em; padding: 3px 10px; border-radius: 12px; font-weight: 500; }
+        .badge-scope { background: rgba(0, 212, 255, 0.15); color: #00d4ff; }
+        .badge-source { background: rgba(46, 213, 115, 0.2); color: #2ed573; }
+        .badge-any-source { background: rgba(162, 155, 254, 0.2); color: #a29bfe; }
+        .badge-new { background: rgba(255, 165, 2, 0.2); color: #ffa502; }
+        .badge-action { background: rgba(253, 121, 168, 0.15); color: #fd79a8; }
+
+        .series-stats { font-size: 0.8em; color: #888; display: flex; flex-direction: column; gap: 4px; }
+        .series-stats span { display: block; }
+
+        .series-actions { display: flex; gap: 6px; margin-top: auto; flex-wrap: wrap; }
+
+        .toggle-switch { position: relative; width: 44px; height: 24px; flex-shrink: 0; }
+        .toggle-switch input { opacity: 0; width: 0; height: 0; }
+        .toggle-slider { position: absolute; cursor: pointer; top: 0; left: 0; right: 0; bottom: 0; background: rgba(255, 255, 255, 0.1); border-radius: 24px; transition: 0.3s; }
+        .toggle-slider:before { content: ""; position: absolute; height: 18px; width: 18px; left: 3px; bottom: 3px; background: #888; border-radius: 50%; transition: 0.3s; }
+        .toggle-switch input:checked + .toggle-slider { background: rgba(0, 212, 255, 0.3); }
+        .toggle-switch input:checked + .toggle-slider:before { transform: translateX(20px); background: #00d4ff; }
+
+        .empty-state { text-align: center; padding: 80px 20px; color: #666; }
+        .empty-state-icon { font-size: 4em; margin-bottom: 20px; opacity: 0.3; }
+        .empty-state h3 { color: #888; margin-bottom: 10px; }
+        .empty-state p { color: #666; margin-bottom: 20px; }
+
+        .loading-spinner { display: inline-block; width: 20px; height: 20px; border: 2px solid rgba(0, 212, 255, 0.1); border-radius: 50%; border-top-color: #00d4ff; animation: spin 1s linear infinite; }
+        @keyframes spin { to { transform: rotate(360deg); } }
+
+        .toast { position: fixed; bottom: 30px; left: 50%; transform: translateX(-50%) translateY(100px); padding: 12px 24px; border-radius: 8px; font-size: 0.95em; z-index: 10000; opacity: 0; transition: all 0.3s ease; }
+        .toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
+        .toast-success { background: linear-gradient(135deg, #2ed573, #1abc9c); color: #000; font-weight: 500; }
+        .toast-info { background: rgba(0, 212, 255, 0.9); color: #000; font-weight: 500; }
+        .toast-error { background: rgba(255, 71, 87, 0.9); color: #fff; font-weight: 500; }
+
+        /* Preview Modal */
+        .modal-overlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.8); display: none; align-items: center; justify-content: center; z-index: 1000; padding: 20px; }
+        .modal-overlay.show { display: flex; }
+        .modal { background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); border: 1px solid rgba(255, 255, 255, 0.15); border-radius: 16px; max-width: 600px; width: 100%; max-height: 90vh; overflow-y: auto; }
+        .modal-header { padding: 20px; border-bottom: 1px solid rgba(255, 255, 255, 0.1); display: flex; justify-content: space-between; align-items: center; }
+        .modal-header h2 { color: #00d4ff; font-size: 1.3em; }
+        .modal-close { background: none; border: none; color: #888; font-size: 1.5em; cursor: pointer; }
+        .modal-close:hover { color: #fff; }
+        .modal-body { padding: 20px; }
+        .modal-footer { padding: 20px; border-top: 1px solid rgba(255, 255, 255, 0.1); display: flex; justify-content: flex-end; gap: 10px; }
+
+        .preview-ep { display: flex; align-items: center; gap: 10px; padding: 8px 12px; border-bottom: 1px solid rgba(255, 255, 255, 0.05); font-size: 0.9em; }
+        .preview-ep .ep-num { color: #888; min-width: 65px; }
+        .preview-ep .ep-title { flex: 1; }
+        .preview-ep .ep-status { font-size: 0.8em; padding: 2px 8px; border-radius: 10px; }
+        .ep-status-new { background: rgba(46, 213, 115, 0.2); color: #2ed573; }
+        .ep-status-known { background: rgba(255, 255, 255, 0.05); color: #888; }
+        .ep-status-downloaded { background: rgba(0, 212, 255, 0.15); color: #00d4ff; }
+
+        .preview-summary { padding: 12px; background: rgba(0, 0, 0, 0.2); border-radius: 8px; margin-bottom: 15px; font-size: 0.9em; }
+        .preview-summary strong { color: #2ed573; }
+
+        .season-group { margin-bottom: 15px; }
+        .season-header { padding: 8px 12px; background: rgba(0, 0, 0, 0.2); border-radius: 6px; margin-bottom: 5px; color: #00d4ff; font-size: 0.9em; font-weight: 600; }
+        .preview-list { max-height: 400px; overflow-y: auto; }
+
+        .check-status { display: flex; align-items: center; gap: 10px; font-size: 0.85em; color: #888; }
+        .check-status .checking { color: #00d4ff; }
+
+        @media (max-width: 768px) {
+            .series-grid { grid-template-columns: 1fr; }
+            .series-card { flex-direction: column; }
+            .series-cover { width: 100%; min-height: 120px; max-height: 180px; }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <div style="display: flex; align-items: center; gap: 12px;">
+                <h1>📡 Series Monitor</h1>
+                <span id="version-badge" style="display: none; font-size: 0.65em; padding: 3px 10px; border-radius: 12px; background: rgba(255,255,255,0.08); color: #888;"></span>
+            </div>
+            <div class="header-nav">
+                <a href="/browse" class="btn btn-secondary">Custom categories & Downloads</a>
+                <a href="/cart" class="btn btn-secondary">🛒 Cart</a>
+                <a href="/" class="btn btn-secondary">Settings</a>
+            </div>
+        </div>
+
+        <div class="header-actions">
+            <button class="btn btn-primary" onclick="triggerCheck()" id="check-btn">🔍 Check Now</button>
+            <div class="check-status" id="check-status" style="display:none;">
+                <div class="loading-spinner"></div>
+                <span class="checking">Checking for new episodes...</span>
+            </div>
+        </div>
+
+        <div id="series-list">
+            <div class="empty-state" id="empty-state">
+                <div class="empty-state-icon">📡</div>
+                <h3>No monitored series</h3>
+                <p>Go to the <a href="/browse" style="color: #00d4ff;">Browse page</a>, find a series, and click the 📡 button to start monitoring.</p>
+            </div>
+        </div>
+    </div>
+
+    <!-- Preview Modal -->
+    <div class="modal-overlay" id="preview-modal">
+        <div class="modal" style="max-width: 650px;">
+            <div class="modal-header">
+                <h2 id="preview-modal-title">Episode Preview</h2>
+                <button class="modal-close" onclick="closePreviewModal()">&times;</button>
+            </div>
+            <div class="modal-body">
+                <div class="preview-summary" id="preview-summary"></div>
+                <div class="preview-list" id="preview-list">
+                    <div style="text-align:center; padding:30px;"><div class="loading-spinner"></div></div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-secondary" onclick="closePreviewModal()">Close</button>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        let monitoredSeries = [];
+        let _checkInterval = null;
+
+        document.addEventListener('DOMContentLoaded', function() {
+            loadMonitored();
+            // Poll for updates every 15 seconds
+            _checkInterval = setInterval(loadMonitored, 15000);
+        });
+
+        async function loadMonitored() {
+            try {
+                const resp = await fetch('/api/monitor');
+                const data = await resp.json();
+                monitoredSeries = data.series || [];
+                renderSeries();
+            } catch (e) {
+                console.error('Error loading monitored series:', e);
+            }
+        }
+
+        function renderSeries() {
+            const container = document.getElementById('series-list');
+            const emptyState = document.getElementById('empty-state');
+
+            if (monitoredSeries.length === 0) {
+                container.innerHTML = '';
+                container.appendChild(emptyState);
+                emptyState.style.display = 'block';
+                return;
+            }
+
+            emptyState.style.display = 'none';
+
+            let html = '<div class="series-grid">';
+            for (const entry of monitoredSeries) {
+                const coverHtml = entry.cover
+                    ? '<img src="' + escapeAttr(entry.cover) + '" onerror="this.style.display=\'none\';this.nextSibling.style.display=\'flex\'" loading="lazy"><span class="placeholder" style="display:none">📺</span>'
+                    : '<span class="placeholder">📺</span>';
+
+                const scopeLabel = entry.scope === 'all' ? 'All episodes'
+                    : entry.scope === 'season' ? 'Season ' + (entry.season_filter || '?')
+                    : 'New only';
+
+                const sourceLabel = entry.source_id
+                    ? (entry.source_name || entry.source_id) + (entry.source_category ? ' (' + entry.source_category + ')' : '')
+                    : 'Any source';
+                const sourceBadgeClass = entry.source_id ? 'badge-source' : 'badge-any-source';
+
+                const actionVal = entry.action || 'both';
+                const actionLabel = actionVal === 'notify' ? '🔔 Notify only'
+                    : actionVal === 'download' ? '⬇ Download only'
+                    : '⬇🔔 Both';
+
+                const lastChecked = entry.last_checked
+                    ? formatRelativeTime(entry.last_checked)
+                    : 'Never';
+
+                const disabledClass = entry.enabled ? '' : ' disabled';
+                const newBadge = entry.last_new_count > 0
+                    ? '<span class="series-badge badge-new">' + entry.last_new_count + ' new</span>'
+                    : '';
+
+                html += '<div class="series-card' + disabledClass + '">' +
+                    '<div class="series-cover">' + coverHtml + '</div>' +
+                    '<div class="series-details">' +
+                    '<div class="series-name">' + escapeHtml(entry.series_name) + '</div>' +
+                    '<div class="series-meta">' +
+                    '<span class="series-badge badge-scope">' + scopeLabel + '</span>' +
+                    '<span class="series-badge ' + sourceBadgeClass + '">' + escapeHtml(sourceLabel) + '</span>' +
+                    '<span class="series-badge badge-action">' + actionLabel + '</span>' +
+                    newBadge +
+                    '</div>' +
+                    '<div class="series-stats">' +
+                    '<span>Known: ' + (entry.known_episodes || []).length + ' episodes</span>' +
+                    '<span>Downloaded: ' + (entry.downloaded_episodes || []).length + ' episodes</span>' +
+                    '<span>Last checked: ' + lastChecked + '</span>' +
+                    '</div>' +
+                    '<div class="series-actions">' +
+                    '<label class="toggle-switch" title="' + (entry.enabled ? 'Disable' : 'Enable') + ' monitoring">' +
+                    '<input type="checkbox" ' + (entry.enabled ? 'checked' : '') + ' onchange="toggleEnabled(\'' + entry.id + '\', this.checked)">' +
+                    '<span class="toggle-slider"></span>' +
+                    '</label>' +
+                    '<button class="btn btn-secondary btn-small" onclick="previewEpisodes(\'' + entry.id + '\', \'' + escapeAttr(entry.series_name) + '\')">👁 Preview</button>' +
+                    '<button class="btn btn-danger btn-small" onclick="deleteMonitored(\'' + entry.id + '\', \'' + escapeAttr(entry.series_name) + '\')">🗑</button>' +
+                    '</div>' +
+                    '</div>' +
+                    '</div>';
+            }
+            html += '</div>';
+            container.innerHTML = html;
+        }
+
+        async function toggleEnabled(id, enabled) {
+            try {
+                await fetch('/api/monitor/' + id, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ enabled: enabled })
+                });
+                showToast(enabled ? 'Monitoring enabled' : 'Monitoring paused', 'info');
+            } catch (e) {
+                showToast('Error updating', 'error');
+            }
+        }
+
+        async function deleteMonitored(id, name) {
+            if (!confirm('Remove monitoring for "' + name + '"?')) return;
+            try {
+                await fetch('/api/monitor/' + id, { method: 'DELETE' });
+                showToast('Removed: ' + name, 'info');
+                await loadMonitored();
+            } catch (e) {
+                showToast('Error removing', 'error');
+            }
+        }
+
+        async function triggerCheck() {
+            const btn = document.getElementById('check-btn');
+            const status = document.getElementById('check-status');
+            btn.disabled = true;
+            status.style.display = 'flex';
+
+            try {
+                await fetch('/api/monitor/check', { method: 'POST' });
+                showToast('Monitoring check started', 'info');
+                // Poll a few times to pick up results
+                let polls = 0;
+                const pollInt = setInterval(async () => {
+                    await loadMonitored();
+                    polls++;
+                    if (polls >= 10) {
+                        clearInterval(pollInt);
+                        btn.disabled = false;
+                        status.style.display = 'none';
+                    }
+                }, 3000);
+            } catch (e) {
+                showToast('Error triggering check', 'error');
+                btn.disabled = false;
+                status.style.display = 'none';
+            }
+        }
+
+        async function previewEpisodes(id, name) {
+            const modal = document.getElementById('preview-modal');
+            document.getElementById('preview-modal-title').textContent = 'Preview: ' + name;
+            document.getElementById('preview-summary').textContent = 'Loading...';
+            document.getElementById('preview-list').innerHTML = '<div style="text-align:center; padding:30px;"><div class="loading-spinner"></div></div>';
+            modal.classList.add('show');
+
+            try {
+                const resp = await fetch('/api/monitor/' + id + '/episodes');
+                const data = await resp.json();
+
+                document.getElementById('preview-summary').innerHTML =
+                    'Total: <strong>' + data.total_episodes + '</strong> episodes — ' +
+                    '<strong>' + data.new_count + '</strong> new (would be downloaded on next check)';
+
+                // Group by season
+                const seasons = {};
+                for (const ep of data.episodes) {
+                    const s = ep.season || '?';
+                    if (!seasons[s]) seasons[s] = [];
+                    seasons[s].push(ep);
+                }
+
+                let html = '';
+                const sortedSeasons = Object.keys(seasons).sort((a, b) => parseInt(a) - parseInt(b));
+                for (const sNum of sortedSeasons) {
+                    html += '<div class="season-group">';
+                    html += '<div class="season-header">Season ' + sNum + ' (' + seasons[sNum].length + ' episodes)</div>';
+                    for (const ep of seasons[sNum]) {
+                        const statusClass = 'ep-status-' + ep.status;
+                        const statusLabel = ep.status === 'new' ? '🆕 New' : ep.status === 'downloaded' ? '✅ Downloaded' : '📋 Known';
+                        html += '<div class="preview-ep">' +
+                            '<span class="ep-num">S' + String(ep.season).padStart(2, '0') + 'E' + String(ep.episode_num).padStart(2, '0') + '</span>' +
+                            '<span class="ep-title">' + escapeHtml(ep.title || 'Episode ' + ep.episode_num) + '</span>' +
+                            '<span class="ep-status ' + statusClass + '">' + statusLabel + '</span>' +
+                            '</div>';
+                    }
+                    html += '</div>';
+                }
+                document.getElementById('preview-list').innerHTML = html;
+            } catch (e) {
+                document.getElementById('preview-list').innerHTML = '<p style="color:#ff4757">Error loading preview</p>';
+            }
+        }
+
+        function closePreviewModal() {
+            document.getElementById('preview-modal').classList.remove('show');
+        }
+
+        function formatRelativeTime(isoStr) {
+            const date = new Date(isoStr);
+            const now = new Date();
+            const diffMs = now - date;
+            const diffMin = Math.floor(diffMs / 60000);
+            if (diffMin < 1) return 'Just now';
+            if (diffMin < 60) return diffMin + 'm ago';
+            const diffHrs = Math.floor(diffMin / 60);
+            if (diffHrs < 24) return diffHrs + 'h ago';
+            const diffDays = Math.floor(diffHrs / 24);
+            return diffDays + 'd ago';
+        }
+
+        function escapeHtml(text) {
+            const div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+
+        function escapeAttr(str) {
+            return String(str || '').replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        }
+
+        function showToast(message, type) {
+            const toast = document.createElement('div');
+            toast.className = 'toast toast-' + type;
+            toast.textContent = message;
+            document.body.appendChild(toast);
+            setTimeout(() => toast.classList.add('show'), 10);
+            setTimeout(() => {
+                toast.classList.remove('show');
+                setTimeout(() => toast.remove(), 300);
+            }, 2000);
+        }
+    </script>
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "xtreamfilter"
-version = "0.3.0"
-description = "A Docker-based Xtream Codes proxy that filters IPTV content with advanced per-category rules and caching"
+version = "0.3.1"
+description = "A Docker-based Xtream Codes proxy that filters IPTV content with advanced per-category rules, caching, Telegram notifications, and download support."
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,312 @@
+"""Tests for the series monitoring feature."""
+
+import os
+import sys
+import json
+import tempfile
+
+# Add app directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "app"))
+
+# Mock the initialization to avoid side effects during import
+os.environ["TESTING"] = "1"
+
+
+class TestMonitoredDataModel:
+    """Tests for monitored series data model and persistence."""
+
+    def test_load_monitored_empty(self):
+        """Test loading monitored series from non-existent file."""
+        import main
+
+        original_file = main.MONITORED_FILE
+        main.MONITORED_FILE = "/tmp/nonexistent_monitored_test.json"
+        try:
+            result = main.load_monitored()
+            assert result == []
+            assert main._monitored_series == []
+        finally:
+            main.MONITORED_FILE = original_file
+
+    def test_save_and_load_monitored(self):
+        """Test round-trip save and load of monitored series."""
+        import main
+
+        original_file = main.MONITORED_FILE
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            temp_file = f.name
+
+        try:
+            main.MONITORED_FILE = temp_file
+
+            test_data = [
+                {
+                    "id": "test-uuid-1",
+                    "series_name": "Breaking Bad",
+                    "series_id": "123",
+                    "source_id": "src1",
+                    "source_name": "Source 1",
+                    "cover": "http://example.com/cover.jpg",
+                    "scope": "new_only",
+                    "season_filter": None,
+                    "enabled": True,
+                    "known_episodes": [
+                        {"stream_id": "1001", "source_id": "src1", "season": "1", "episode_num": 1},
+                        {"stream_id": "1002", "source_id": "src1", "season": "1", "episode_num": 2},
+                    ],
+                    "downloaded_episodes": [],
+                    "created_at": "2026-01-01T00:00:00",
+                    "last_checked": None,
+                    "last_new_count": 0,
+                }
+            ]
+
+            main.save_monitored(test_data)
+
+            # Verify file content
+            with open(temp_file) as f:
+                saved = json.load(f)
+            assert "series" in saved
+            assert len(saved["series"]) == 1
+            assert saved["series"][0]["series_name"] == "Breaking Bad"
+
+            # Verify reload
+            loaded = main.load_monitored()
+            assert len(loaded) == 1
+            assert loaded[0]["id"] == "test-uuid-1"
+            assert loaded[0]["series_name"] == "Breaking Bad"
+            assert len(loaded[0]["known_episodes"]) == 2
+        finally:
+            main.MONITORED_FILE = original_file
+            os.unlink(temp_file)
+
+    def test_load_monitored_corrupt_file(self):
+        """Test loading from a corrupt JSON file."""
+        import main
+
+        original_file = main.MONITORED_FILE
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("not valid json{{{")
+            temp_file = f.name
+
+        try:
+            main.MONITORED_FILE = temp_file
+            result = main.load_monitored()
+            assert result == []
+        finally:
+            main.MONITORED_FILE = original_file
+            os.unlink(temp_file)
+
+
+class TestMonitorDiffLogic:
+    """Tests for the episode diff detection logic."""
+
+    def test_new_episodes_detected(self):
+        """Test that new episodes are correctly identified via diff."""
+        # Simulate the diff logic used in _check_single_monitored
+        known_episodes = [
+            {"stream_id": "1001", "source_id": "src1", "season": "1", "episode_num": 1},
+            {"stream_id": "1002", "source_id": "src1", "season": "1", "episode_num": 2},
+            {"stream_id": "1003", "source_id": "src1", "season": "1", "episode_num": 3},
+        ]
+        downloaded_episodes = [
+            {"stream_id": "1004", "source_id": "src1", "season": "1", "episode_num": 4},
+        ]
+
+        # Simulated fetched episodes (includes all known + 2 new)
+        fetched_episodes = [
+            {"stream_id": "1001", "season": "1", "episode_num": 1, "title": "Pilot"},
+            {"stream_id": "1002", "season": "1", "episode_num": 2, "title": "Cat's in the Bag"},
+            {"stream_id": "1003", "season": "1", "episode_num": 3, "title": "And the Bag's in the River"},
+            {"stream_id": "1004", "season": "1", "episode_num": 4, "title": "Cancer Man"},
+            {"stream_id": "1005", "season": "1", "episode_num": 5, "title": "Gray Matter"},
+            {"stream_id": "1006", "season": "1", "episode_num": 6, "title": "Crazy Handful of Nothin'"},
+        ]
+
+        # Diff logic
+        known_keys = {
+            (str(k.get("season")), int(k.get("episode_num", 0))) for k in known_episodes
+        }
+        downloaded_keys = {
+            (str(k.get("season")), int(k.get("episode_num", 0))) for k in downloaded_episodes
+        }
+        already_seen = known_keys | downloaded_keys
+
+        new_episodes = []
+        for ep in fetched_episodes:
+            ep_key = (str(ep.get("season")), int(ep.get("episode_num", 0)))
+            if ep_key not in already_seen:
+                new_episodes.append(ep)
+
+        assert len(new_episodes) == 2
+        assert new_episodes[0]["title"] == "Gray Matter"
+        assert new_episodes[1]["title"] == "Crazy Handful of Nothin'"
+
+    def test_no_new_episodes(self):
+        """Test when all episodes are already known."""
+        known_episodes = [
+            {"season": "1", "episode_num": 1},
+            {"season": "1", "episode_num": 2},
+        ]
+        fetched_episodes = [
+            {"stream_id": "1001", "season": "1", "episode_num": 1},
+            {"stream_id": "1002", "season": "1", "episode_num": 2},
+        ]
+
+        known_keys = {(str(k["season"]), int(k["episode_num"])) for k in known_episodes}
+        new_episodes = [
+            ep for ep in fetched_episodes
+            if (str(ep["season"]), int(ep["episode_num"])) not in known_keys
+        ]
+
+        assert len(new_episodes) == 0
+
+    def test_empty_known_detects_all(self):
+        """Test scope='all' behavior (known_episodes empty → everything is new)."""
+        known_episodes = []
+        fetched_episodes = [
+            {"stream_id": "1001", "season": "1", "episode_num": 1},
+            {"stream_id": "1002", "season": "1", "episode_num": 2},
+            {"stream_id": "1003", "season": "2", "episode_num": 1},
+        ]
+
+        known_keys = {(str(k["season"]), int(k["episode_num"])) for k in known_episodes}
+        new_episodes = [
+            ep for ep in fetched_episodes
+            if (str(ep["season"]), int(ep["episode_num"])) not in known_keys
+        ]
+
+        assert len(new_episodes) == 3
+
+
+class TestMonitorScopeFilters:
+    """Tests for monitoring scope filtering."""
+
+    def test_scope_season_filter(self):
+        """Test season scope only keeps episodes from the target season."""
+        episodes = [
+            {"stream_id": "1", "season": "1", "episode_num": 1},
+            {"stream_id": "2", "season": "1", "episode_num": 2},
+            {"stream_id": "3", "season": "2", "episode_num": 1},
+            {"stream_id": "4", "season": "2", "episode_num": 2},
+            {"stream_id": "5", "season": "3", "episode_num": 1},
+        ]
+
+        season_filter = "2"
+        filtered = [ep for ep in episodes if str(ep.get("season")) == str(season_filter)]
+
+        assert len(filtered) == 2
+        assert all(ep["season"] == "2" for ep in filtered)
+
+    def test_scope_all_no_filter(self):
+        """Test 'all' scope doesn't filter any episodes."""
+        episodes = [
+            {"stream_id": "1", "season": "1", "episode_num": 1},
+            {"stream_id": "2", "season": "2", "episode_num": 1},
+        ]
+
+        scope = "all"
+        # No filter applied for scope=all
+        filtered = episodes  # identity
+        assert len(filtered) == 2
+
+    def test_scope_new_only_snapshot(self):
+        """Test 'new_only' scope: snapshot at activation means all current eps are known."""
+        current_episodes = [
+            {"stream_id": "1", "season": "1", "episode_num": 1},
+            {"stream_id": "2", "season": "1", "episode_num": 2},
+        ]
+
+        # Snapshot all current as known
+        known_episodes = [
+            {"season": str(ep["season"]), "episode_num": int(ep["episode_num"])}
+            for ep in current_episodes
+        ]
+
+        # Later check finds same + 1 new
+        later_episodes = current_episodes + [
+            {"stream_id": "3", "season": "1", "episode_num": 3},
+        ]
+
+        known_keys = {(str(k["season"]), int(k["episode_num"])) for k in known_episodes}
+        new_eps = [ep for ep in later_episodes if (str(ep["season"]), int(ep["episode_num"])) not in known_keys]
+
+        assert len(new_eps) == 1
+        assert new_eps[0]["episode_num"] == 3
+
+
+class TestCrossSourceMatching:
+    """Tests for cross-source series name matching via normalize_name."""
+
+    def test_normalize_strips_prefix(self):
+        from main import normalize_name
+
+        assert normalize_name("FR - Breaking Bad") == normalize_name("Breaking Bad")
+
+    def test_normalize_strips_quality(self):
+        from main import normalize_name
+
+        assert normalize_name("Breaking Bad 4K") == normalize_name("Breaking Bad")
+        assert normalize_name("Breaking Bad UHD HDR") == normalize_name("Breaking Bad")
+
+    def test_normalize_strips_language_suffix(self):
+        from main import normalize_name
+
+        assert normalize_name("Breaking Bad_fr") == normalize_name("Breaking Bad")
+
+    def test_normalize_strips_year(self):
+        from main import normalize_name
+
+        assert normalize_name("Industry - 2024") == normalize_name("Industry")
+
+    def test_fuzzy_match_across_sources(self):
+        """Test that similar names from different sources match via fuzzy."""
+        from main import normalize_name
+        from rapidfuzz import fuzz
+
+        name_a = normalize_name("FR - The Bear (2022)")
+        name_b = normalize_name("NF - The Bear")
+
+        score = fuzz.token_sort_ratio(name_a, name_b)
+        assert score >= 90, f"Expected score >= 90 but got {score}"
+
+    def test_different_series_dont_match(self):
+        """Test that genuinely different series don't match."""
+        from main import normalize_name
+        from rapidfuzz import fuzz
+
+        name_a = normalize_name("Breaking Bad")
+        name_b = normalize_name("Better Call Saul")
+
+        score = fuzz.token_sort_ratio(name_a, name_b)
+        assert score < 90, f"Expected score < 90 but got {score}"
+
+
+class TestDuplicatePrevention:
+    """Tests for preventing duplicate downloads in the monitored pipeline."""
+
+    def test_episode_key_based_on_season_and_num(self):
+        """Test that episode identity is based on (season, episode_num), not stream_id.
+        This ensures the same logical episode from different sources isn't treated as different."""
+
+        # Same episode from different sources
+        ep_source_a = {"stream_id": "1001", "source_id": "srcA", "season": "2", "episode_num": 5}
+        ep_source_b = {"stream_id": "9999", "source_id": "srcB", "season": "2", "episode_num": 5}
+
+        key_a = (str(ep_source_a["season"]), int(ep_source_a["episode_num"]))
+        key_b = (str(ep_source_b["season"]), int(ep_source_b["episode_num"]))
+
+        assert key_a == key_b, "Same logical episode from different sources should have the same key"
+
+    def test_different_episodes_have_different_keys(self):
+        """Different episodes should have different keys."""
+        ep_a = {"season": "1", "episode_num": 1}
+        ep_b = {"season": "1", "episode_num": 2}
+        ep_c = {"season": "2", "episode_num": 1}
+
+        keys = {
+            (str(ep["season"]), int(ep["episode_num"]))
+            for ep in [ep_a, ep_b, ep_c]
+        }
+
+        assert len(keys) == 3


### PR DESCRIPTION
Automatically track your favorite series for new episodes. Add any series to the monitor from the browse page, choose a scope (new episodes only, specific season, or all), and set an action (download, notify via Telegram, or both). The monitor checks for new episodes after each cache refresh and can auto-queue them for download. Includes an episode preview modal showing known, downloaded, and new episodes grouped by season.