### PR TITLE
Fixed custom series name

### DIFF
--- a/app/services/cart_service.py
+++ b/app/services/cart_service.py
@@ -769,6 +769,12 @@ class CartService:
                                 meta_title = _str_val(
                                     info.get("name") or info.get("title")
                                 ).strip()
+                                if _cur_sname and _cur_sname != meta_title:
+                                    logger.info(
+                                        f"[META] Preferring user-defined series name: "
+                                        f"'{_cur_sname}' instead of '{meta_title}'"
+                                    )
+                                    return
                                 if meta_title:
                                     year = _extract_year(info)
                                     if year and year not in meta_title:


### PR DESCRIPTION
Fixed overwrite of user-defined series_name if series is not monitored.

This happens if you add a series to the card that is currently not monitored.
When starting the download, the series_name will be set by `_enrich_item_name_from_metadata`. 

Could you please check the changes for potentail side-effects? 
I've tested it and it worked great on my side.