### PR TITLE
Improve Xtream filtering performance and handle null category IDs

### DIFF
--- a/app/routes/xtream_merged.py
+++ b/app/routes/xtream_merged.py
@@ -174,15 +174,30 @@ def _handle_get_streams(action: str, request: Request, enabled_sources, cache: C
         channel_filters = filters.get(ct, {}).get("channels", [])
         categories = cache.get_cached(cat_key, source_id)
         cat_map = build_category_map(categories)
+        allowed_category_ids = {
+            cat_id
+            for cat_id, group_name in cat_map.items()
+            if should_include(group_name, group_filters)
+        }
+        include_unknown_group = should_include("", group_filters)
 
         for stream in cache.get_cached(stream_key, source_id):
             cat_id = str(stream.get("category_id", ""))
-            group_name = cat_map.get(cat_id, "")
-            channel_name = stream.get("name", "")
             stream_id_raw = str(stream.get(id_field, ""))
+            group_allowed = (
+                cat_id in allowed_category_ids
+                if cat_id in cat_map
+                else include_unknown_group
+            )
 
-            if should_include(group_name, group_filters) and should_include(channel_name, channel_filters):
-                virtual_cat_id = str(encode_virtual_id(idx, stream.get("category_id", 0)))
+            if group_allowed:
+                channel_name = stream.get("name", "")
+                if channel_filters and not should_include(channel_name, channel_filters):
+                    group_allowed = False
+
+            if group_allowed:
+                raw_category_id = stream.get("category_id") or 0
+                virtual_cat_id = str(encode_virtual_id(idx, raw_category_id))
                 if requested_cat_id is None or requested_cat_id == virtual_cat_id:
                     stream_copy = stream.copy()
                     stream_copy[id_field] = encode_virtual_id(idx, stream.get(id_field, 0))

--- a/app/routes/xtream_source.py
+++ b/app/routes/xtream_source.py
@@ -98,18 +98,34 @@ async def player_api_source(
             streams = cache.get_cached(f"{ct}_streams", source_id)
             categories = cache.get_cached(f"{ct}_categories", source_id)
             cat_map = build_category_map(categories)
+            allowed_category_ids = {
+                cat_id
+                for cat_id, group_name in cat_map.items()
+                if should_include(group_name, group_filters)
+            }
+            include_unknown_group = should_include("", group_filters)
+
             result = []
             for stream in streams:
                 cat_id = str(stream.get("category_id", ""))
-                group_name = cat_map.get(cat_id, "")
+                group_allowed = (
+                    cat_id in allowed_category_ids
+                    if cat_id in cat_map
+                    else include_unknown_group
+                )
+                if not group_allowed:
+                    continue
+
                 channel_name = stream.get("name", "")
-                if should_include(group_name, group_filters) and should_include(channel_name, channel_filters):
-                    stream_copy = stream.copy()
-                    if ct == "live":
-                        epg_id = stream.get("epg_channel_id", "")
-                        if epg_id:
-                            stream_copy["epg_channel_id"] = f"{source_id}_{epg_id}".lower()
-                    result.append(stream_copy)
+                if channel_filters and not should_include(channel_name, channel_filters):
+                    continue
+
+                stream_copy = stream.copy()
+                if ct == "live":
+                    epg_id = stream.get("epg_channel_id", "")
+                    if epg_id:
+                        stream_copy["epg_channel_id"] = f"{source_id}_{epg_id}".lower()
+                result.append(stream_copy)
             return result
 
         elif action == "get_series":
@@ -118,11 +134,29 @@ async def player_api_source(
             series_list = cache.get_cached("series", source_id)
             categories = cache.get_cached("series_categories", source_id)
             cat_map = build_category_map(categories)
-            return [
-                s for s in series_list
-                if should_include(cat_map.get(str(s.get("category_id", "")), ""), group_filters)
-                and should_include(s.get("name", ""), channel_filters)
-            ]
+            allowed_category_ids = {
+                cat_id
+                for cat_id, group_name in cat_map.items()
+                if should_include(group_name, group_filters)
+            }
+            include_unknown_group = should_include("", group_filters)
+
+            result = []
+            for series in series_list:
+                cat_id = str(series.get("category_id", ""))
+                group_allowed = (
+                    cat_id in allowed_category_ids
+                    if cat_id in cat_map
+                    else include_unknown_group
+                )
+                if not group_allowed:
+                    continue
+
+                if channel_filters and not should_include(series.get("name", ""), channel_filters):
+                    continue
+
+                result.append(series)
+            return result
 
         elif action in ("get_series_info", "get_vod_info"):
             param_key = "series_id" if action == "get_series_info" else "vod_id"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -662,3 +662,242 @@ def test_cart_page(client):
 def test_monitor_page(client):
     r = client.get("/monitor")
     assert r.status_code == 200
+
+# -------------------------------------------------------------------
+# Xtream filtering performance / malformed category regression tests
+# -------------------------------------------------------------------
+
+
+def _configure_xtream_source(client, *, filters=None):
+    """Install a single cached source without making upstream HTTP requests."""
+    source = {
+        "id": "source-1",
+        "name": "Test source",
+        "host": "http://upstream.invalid",
+        "username": "user",
+        "password": "pass",
+        "enabled": True,
+        "route": "test-source",
+        "prefix": "",
+        "filters": filters or {
+            "live": {"groups": [], "channels": []},
+            "vod": {"groups": [], "channels": []},
+            "series": {"groups": [], "channels": []},
+        },
+    }
+    cfg = client.app.state.config_service
+    cfg.config["sources"] = [source]
+    cfg.save()
+
+    cache = client.app.state.cache_service
+    cache._api_cache["sources"] = {
+        source["id"]: cache._empty_source_cache(),
+    }
+    return source, cache._api_cache["sources"][source["id"]]
+
+
+def test_source_vod_group_filters_are_evaluated_per_category(client, monkeypatch):
+    """Group rules should not be re-evaluated for every VOD item."""
+    from app.routes import xtream_source
+    from app.services.filter_service import should_include as real_should_include
+
+    filters = {
+        "live": {"groups": [], "channels": []},
+        "vod": {
+            "groups": [
+                {
+                    "type": "include",
+                    "match": "exact",
+                    "value": "Allowed",
+                    "case_sensitive": False,
+                }
+            ],
+            "channels": [],
+        },
+        "series": {"groups": [], "channels": []},
+    }
+    _, source_cache = _configure_xtream_source(client, filters=filters)
+    source_cache["vod_categories"] = [
+        {"category_id": "10", "category_name": "Allowed"},
+        {"category_id": "20", "category_name": "Blocked"},
+    ]
+    source_cache["vod_streams"] = [
+        {"stream_id": i, "name": f"Allowed {i}", "category_id": "10"}
+        for i in range(100)
+    ] + [
+        {"stream_id": 1000 + i, "name": f"Blocked {i}", "category_id": "20"}
+        for i in range(100)
+    ] + [
+        {"stream_id": 9999, "name": "Unknown category", "category_id": None},
+    ]
+
+    calls = []
+
+    def counting_should_include(value, rules):
+        calls.append((value, rules))
+        return real_should_include(value, rules)
+
+    monkeypatch.setattr(xtream_source, "should_include", counting_should_include)
+
+    response = client.get("/test-source/player_api.php?action=get_vod_streams")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 100
+    assert {item["category_id"] for item in data} == {"10"}
+
+    # Two known category names plus the unknown-category fallback.  Most
+    # importantly, this must not scale with the 201 VOD items above.
+    assert len(calls) == 3
+
+
+def test_source_series_filtering_preserves_group_and_channel_semantics(client):
+    filters = {
+        "live": {"groups": [], "channels": []},
+        "vod": {"groups": [], "channels": []},
+        "series": {
+            "groups": [
+                {
+                    "type": "include",
+                    "match": "exact",
+                    "value": "Allowed Series",
+                    "case_sensitive": False,
+                }
+            ],
+            "channels": [
+                {
+                    "type": "exclude",
+                    "match": "contains",
+                    "value": "Blocked",
+                    "case_sensitive": False,
+                }
+            ],
+        },
+    }
+    _, source_cache = _configure_xtream_source(client, filters=filters)
+    source_cache["series_categories"] = [
+        {"category_id": "10", "category_name": "Allowed Series"},
+        {"category_id": "20", "category_name": "Other Series"},
+    ]
+    source_cache["series"] = [
+        {"series_id": 1, "name": "Keep Me", "category_id": "10"},
+        {"series_id": 2, "name": "Blocked title", "category_id": "10"},
+        {"series_id": 3, "name": "Wrong category", "category_id": "20"},
+        {"series_id": 4, "name": "Unknown category", "category_id": None},
+    ]
+
+    response = client.get("/test-source/player_api.php?action=get_series")
+    assert response.status_code == 200
+    assert [item["series_id"] for item in response.json()] == [1]
+
+
+def test_merged_vod_handles_null_category_id(client):
+    """A provider item with category_id=null must not fail the whole catalog."""
+    _, source_cache = _configure_xtream_source(client)
+    source_cache["vod_categories"] = []
+    source_cache["vod_streams"] = [
+        {
+            "stream_id": 123,
+            "name": "Uncategorised movie",
+            "category_id": None,
+        }
+    ]
+
+    response = client.get("/merged/player_api.php?action=get_vod_streams")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["stream_id"] == 123
+    assert data[0]["category_id"] == "0"
+    assert data[0]["category_ids"] == [0]
+
+
+def test_merged_vod_preserves_category_and_channel_filters(client):
+    filters = {
+        "live": {"groups": [], "channels": []},
+        "vod": {
+            "groups": [
+                {
+                    "type": "include",
+                    "match": "exact",
+                    "value": "Allowed",
+                    "case_sensitive": False,
+                }
+            ],
+            "channels": [
+                {
+                    "type": "exclude",
+                    "match": "contains",
+                    "value": "Blocked",
+                    "case_sensitive": False,
+                }
+            ],
+        },
+        "series": {"groups": [], "channels": []},
+    }
+    _, source_cache = _configure_xtream_source(client, filters=filters)
+    source_cache["vod_categories"] = [
+        {"category_id": "10", "category_name": "Allowed"},
+        {"category_id": "20", "category_name": "Other"},
+    ]
+    source_cache["vod_streams"] = [
+        {"stream_id": 1, "name": "Keep", "category_id": "10"},
+        {"stream_id": 2, "name": "Blocked title", "category_id": "10"},
+        {"stream_id": 3, "name": "Wrong category", "category_id": "20"},
+        {"stream_id": 4, "name": "Unknown category", "category_id": None},
+    ]
+
+    response = client.get("/merged/player_api.php?action=get_vod_streams")
+    assert response.status_code == 200
+    data = response.json()
+    assert [item["stream_id"] for item in data] == [1]
+    assert data[0]["category_id"] == "10"
+    assert data[0]["category_ids"] == [10]
+
+
+def test_merged_vod_group_filters_are_evaluated_per_category(client, monkeypatch):
+    """Merged group rules should scale with categories, not stream count."""
+    from app.routes import xtream_merged
+    from app.services.filter_service import should_include as real_should_include
+
+    filters = {
+        "live": {"groups": [], "channels": []},
+        "vod": {
+            "groups": [
+                {
+                    "type": "include",
+                    "match": "exact",
+                    "value": "Allowed",
+                    "case_sensitive": False,
+                }
+            ],
+            "channels": [],
+        },
+        "series": {"groups": [], "channels": []},
+    }
+    _, source_cache = _configure_xtream_source(client, filters=filters)
+    source_cache["vod_categories"] = [
+        {"category_id": "10", "category_name": "Allowed"},
+        {"category_id": "20", "category_name": "Blocked"},
+    ]
+    source_cache["vod_streams"] = [
+        {"stream_id": i, "name": f"Allowed {i}", "category_id": "10"}
+        for i in range(100)
+    ] + [
+        {"stream_id": 1000 + i, "name": f"Blocked {i}", "category_id": "20"}
+        for i in range(100)
+    ] + [
+        {"stream_id": 9999, "name": "Unknown category", "category_id": None},
+    ]
+
+    calls = []
+
+    def counting_should_include(value, rules):
+        calls.append((value, rules))
+        return real_should_include(value, rules)
+
+    monkeypatch.setattr(xtream_merged, "should_include", counting_should_include)
+
+    response = client.get("/merged/player_api.php?action=get_vod_streams")
+    assert response.status_code == 200
+    assert len(response.json()) == 100
+    assert len(calls) == 3


### PR DESCRIPTION
## Summary

This PR improves the performance of filtered Xtream endpoints for large provider catalogs and makes the merged API resilient to upstream VOD items with a null `category_id`.

### Filtering performance

The filtered source and merged routes currently evaluate the category/group rules again for every individual stream or series item. Large catalogs can contain hundreds of thousands of items while only having a relatively small number of categories, so the same group name is matched against the same filters many thousands of times.

This change precomputes the set of allowed category IDs once per source/request and then uses set membership while iterating over streams. It also skips channel-filter evaluation when no channel filters are configured.

The existing filter rules and their semantics are preserved, including the behaviour for items whose category ID is not present in the category map.

### Real-world benchmark

The issue was reproduced with a large IPTV catalog containing roughly 210,000 VOD entries and a merged setup with category filters.

`/merged/player_api.php?action=get_vod_streams`

Before:

- TTFB: `66.489446 s`
- Total: `66.682150 s`
- Response size: `5,763,836 bytes`

After:

- TTFB: `1.349130 s`
- Total: `1.561021 s`
- Response size: `5,763,836 bytes`

That is approximately a **49.3x improvement in TTFB** (about **98% lower**) with an identical response size.

For comparison, the unfiltered `/full` VOD response in the same environment was `80,854,806 bytes` with a TTFB of about `8.59 s`.

### Null category IDs

One upstream provider returned VOD items like:

```json
{
  "stream_id": 123,
  "category_id": null
}
```

In the affected catalog, 224 entries had a null category ID. The merged route passed that value to the virtual-ID code and later attempted to convert the result to an integer, causing the entire `get_vod_streams` request to fail with:

```text
invalid literal for int() with base 10: 'None'
```

This PR normalizes a null/empty category ID to `0` before virtual category-ID generation, so a malformed/uncategorized provider entry can no longer fail the entire merged catalog.

## Changes

- Precompute allowed category IDs for filtered live/VOD endpoints.
- Apply the same category filtering optimization to series.
- Apply the optimization per source in the merged live/VOD/series path.
- Skip `should_include()` for channel names when no channel filters exist.
- Preserve existing unknown-category filter semantics.
- Handle null category IDs safely during merged virtual-ID generation.
- Add regression tests covering filtering semantics, call scaling, and null category IDs.

## Tests

New regression tests verify that:

- source VOD group-filter evaluations scale with categories rather than stream count;
- merged VOD group-filter evaluations scale with categories rather than stream count;
- series group and channel filtering semantics are preserved;
- merged group and channel filtering semantics are preserved;
- `category_id: null` no longer causes an HTTP 500.

The new targeted regression tests pass (`5 passed`). They were also run against the unmodified code to confirm they fail for the original performance behaviour and null-category crash.

Project test command:

```bash
uv run pytest tests/ -v
```
